### PR TITLE
Invalid parameter in call to run_semaphore fixed

### DIFF
--- a/semaphore.py
+++ b/semaphore.py
@@ -150,6 +150,6 @@ def semaphore(text='', files='', semaphore=release):
     else:
         sample='../samples/sample.txt'
 
-    run_semaphore(semaphore=semaphore, sample=sample)
+    run_semaphore(release=semaphore, sample=sample)
 
     return import_semaphore()


### PR DESCRIPTION
The call to run_semaphore() on line 153 in semaphore(), used the incorrect parameter name "semaphore". This should be called "release". This parameter passes the path to the SEMAFOR installation.
